### PR TITLE
Prevent crashes in the WidgetKit descriptor hook

### DIFF
--- a/MyWidget/FooObject.mm
+++ b/MyWidget/FooObject.mm
@@ -6,6 +6,7 @@
 //
 
 #import "FooObject.h"
+#import <dispatch/dispatch.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
 
@@ -13,7 +14,10 @@
     NSArray *_activityDescriptors;
     NSArray *_controlDescriptors;
     NSArray *_widgetDescriptors;
+    BOOL _didPatchTarget;
 }
+
+@property(nonatomic, readonly) BOOL didPatchTarget;
 @end
 @implementation MyDescriptorFetchResult
 
@@ -21,11 +25,31 @@
     return YES;
 }
 
+- (BOOL)didPatchTarget {
+    return _didPatchTarget;
+}
+
 - (instancetype)initWithCoder:(NSCoder *)coder {
     if (self = [super init]) {
-        NSArray *activityDescriptors = [coder decodeObjectOfClasses:[NSSet setWithObjects:NSArray.class, objc_lookUpClass("CHSBaseDescriptor"), nil] forKey:@"activityDescriptors"];
-        NSArray *controlDescriptors = [coder decodeObjectOfClasses:[NSSet setWithObjects:NSArray.class, objc_lookUpClass("CHSControlDescriptor"), nil] forKey:@"controlDescriptors"];
-        NSArray *widgetDescriptors = [coder decodeObjectOfClasses:[NSSet setWithObjects:NSArray.class, objc_lookUpClass("CHSWidgetDescriptor"), nil] forKey:@"widgetDescriptors"];
+        Class baseDescriptorClass = objc_lookUpClass("CHSBaseDescriptor");
+        Class controlDescriptorClass = objc_lookUpClass("CHSControlDescriptor");
+        Class widgetDescriptorClass = objc_lookUpClass("CHSWidgetDescriptor");
+        NSSet *activityClasses = baseDescriptorClass
+            ? [NSSet setWithObjects:NSArray.class, baseDescriptorClass, nil]
+            : [NSSet setWithObject:NSArray.class];
+        NSSet *controlClasses = controlDescriptorClass
+            ? [NSSet setWithObjects:NSArray.class, controlDescriptorClass, nil]
+            : [NSSet setWithObject:NSArray.class];
+        NSSet *widgetClasses = widgetDescriptorClass
+            ? [NSSet setWithObjects:NSArray.class, widgetDescriptorClass, nil]
+            : [NSSet setWithObject:NSArray.class];
+
+        NSArray *activityDescriptors = [coder decodeObjectOfClasses:activityClasses
+                                                              forKey:@"activityDescriptors"];
+        NSArray *controlDescriptors = [coder decodeObjectOfClasses:controlClasses
+                                                             forKey:@"controlDescriptors"];
+        NSArray *widgetDescriptors = [coder decodeObjectOfClasses:widgetClasses
+                                                            forKey:@"widgetDescriptors"];
         
         //
         
@@ -34,21 +58,38 @@
         for (id widgetDescriptor in widgetDescriptors) {
             NSString *kind = reinterpret_cast<id (*)(id, SEL)>(objc_msgSend)(widgetDescriptor, sel_registerName("kind"));
             
-            if ([kind isEqualToString:@"MyClearWidget"]) {
+            BOOL isClearWidget = [kind isEqualToString:@"MyClearWidget"];
+            BOOL isBlurWidget = [kind isEqualToString:@"MyBlurWidget"];
+            if (isClearWidget || isBlurWidget) {
                 id mutableWidgetDescriptor = [widgetDescriptor mutableCopy];
-                reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(mutableWidgetDescriptor, sel_registerName("setBackgroundRemovable:"), YES);
-                reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(mutableWidgetDescriptor, sel_registerName("setTransparent:"), YES);
-                reinterpret_cast<void (*)(id, SEL, NSUInteger)>(objc_msgSend)(mutableWidgetDescriptor, sel_registerName("setPreferredBackgroundStyle:"), 0x1);
+                SEL removableSelector = sel_registerName("setBackgroundRemovable:");
+                SEL transparentSelector = sel_registerName("setTransparent:");
+                SEL vibrantContentSelector = sel_registerName("setSupportsVibrantContent:");
+                SEL preferredStyleSelector = sel_registerName("setPreferredBackgroundStyle:");
+                BOOL supportsPatch = mutableWidgetDescriptor
+                    && [mutableWidgetDescriptor respondsToSelector:removableSelector]
+                    && [mutableWidgetDescriptor respondsToSelector:transparentSelector]
+                    && [mutableWidgetDescriptor respondsToSelector:preferredStyleSelector]
+                    && (!isBlurWidget || [mutableWidgetDescriptor respondsToSelector:vibrantContentSelector]);
+                if (!supportsPatch) {
+                    [newWidgetDescriptors addObject:widgetDescriptor];
+                    [mutableWidgetDescriptor release];
+                    continue;
+                }
+
+                reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(
+                    mutableWidgetDescriptor, removableSelector, YES);
+                reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(
+                    mutableWidgetDescriptor, transparentSelector, YES);
+                if (isBlurWidget) {
+                    reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(
+                        mutableWidgetDescriptor, vibrantContentSelector, YES);
+                }
+                reinterpret_cast<void (*)(id, SEL, NSUInteger)>(objc_msgSend)(
+                    mutableWidgetDescriptor, preferredStyleSelector, isBlurWidget ? 0x2 : 0x1);
                 [newWidgetDescriptors addObject:mutableWidgetDescriptor];
                 [mutableWidgetDescriptor release];
-            } else if ([kind isEqualToString:@"MyBlurWidget"]) {
-                id mutableWidgetDescriptor = [widgetDescriptor mutableCopy];
-                reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(mutableWidgetDescriptor, sel_registerName("setBackgroundRemovable:"), YES);
-                reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(mutableWidgetDescriptor, sel_registerName("setTransparent:"), YES);
-                reinterpret_cast<void (*)(id, SEL, BOOL)>(objc_msgSend)(mutableWidgetDescriptor, sel_registerName("setSupportsVibrantContent:"), YES);
-                reinterpret_cast<void (*)(id, SEL, NSUInteger)>(objc_msgSend)(mutableWidgetDescriptor, sel_registerName("setPreferredBackgroundStyle:"), 0x2);
-                [newWidgetDescriptors addObject:mutableWidgetDescriptor];
-                [mutableWidgetDescriptor release];
+                _didPatchTarget = YES;
             } else {
                 [newWidgetDescriptors addObject:widgetDescriptor];
             }
@@ -83,6 +124,11 @@ namespace custom_ExportedObject {
         void (*original)(id, SEL, id);
         void custom(id self, SEL _cmd, void (^completion)(id fetchResult)) {
             original(self, _cmd, ^(id fetchResult_1) {
+                if (!fetchResult_1 || ![fetchResult_1 respondsToSelector:@selector(encodeWithCoder:)]) {
+                    completion(fetchResult_1);
+                    return;
+                }
+
                 NSError * _Nullable error = nil;
                 
                 NSKeyedArchiver *archiver_1 = [[NSKeyedArchiver alloc] initRequiringSecureCoding:YES];
@@ -94,7 +140,7 @@ namespace custom_ExportedObject {
                 //
                 
                 NSKeyedUnarchiver *unarchiver_1 = [[NSKeyedUnarchiver alloc] initForReadingFromData:encodedData_1 error:&error];
-                if (error != nil) {
+                if (error != nil || unarchiver_1 == nil) {
                     completion(fetchResult_1);
                     [unarchiver_1 release];
                     return;
@@ -102,6 +148,11 @@ namespace custom_ExportedObject {
                 
                 MyDescriptorFetchResult *fetchResult_2 = [[MyDescriptorFetchResult alloc] initWithCoder:unarchiver_1];
                 [unarchiver_1 release];
+                if (fetchResult_2 == nil || !fetchResult_2.didPatchTarget) {
+                    [fetchResult_2 release];
+                    completion(fetchResult_1);
+                    return;
+                }
                 
                 NSKeyedArchiver *archiver_2 = [[NSKeyedArchiver alloc] initRequiringSecureCoding:YES];
                 [fetchResult_2 encodeWithCoder:archiver_2];
@@ -111,22 +162,36 @@ namespace custom_ExportedObject {
                 
                 //
                 
+                error = nil;
                 NSKeyedUnarchiver *unarchiver_3 = [[NSKeyedUnarchiver alloc] initForReadingFromData:encodedData_2 error:&error];
-                if (error != nil) {
+                Class descriptorFetchResultClass = objc_lookUpClass("_TtC9WidgetKit21DescriptorFetchResult");
+                if (error != nil || unarchiver_3 == nil || descriptorFetchResultClass == nil) {
                     [unarchiver_3 release];
                     completion(fetchResult_1);
                     return;
                 }
                 
-                id fetchResult_3 = reinterpret_cast<id (*)(id, SEL, id)>(objc_msgSend)([objc_lookUpClass("_TtC9WidgetKit21DescriptorFetchResult") alloc], @selector(initWithCoder:), unarchiver_3);
+                id fetchResult_3 = [[descriptorFetchResultClass alloc] initWithCoder:unarchiver_3];
                 [unarchiver_3 release];
-                
+                if (fetchResult_3 == nil) {
+                    completion(fetchResult_1);
+                    return;
+                }
+
                 completion(fetchResult_3);
                 [fetchResult_3 release];
             });
         }
         void swizzle() {
-            Method method = class_getInstanceMethod(objc_lookUpClass("_TtCC9WidgetKit24WidgetExtensionXPCServer14ExportedObject"), sel_registerName("getAllCurrentDescriptorsWithCompletion:"));
+            if (original != nil) {
+                return;
+            }
+
+            Class exportedObject = objc_lookUpClass("_TtCC9WidgetKit24WidgetExtensionXPCServer14ExportedObject");
+            Method method = class_getInstanceMethod(exportedObject, sel_registerName("getAllCurrentDescriptorsWithCompletion:"));
+            if (method == nil) {
+                return;
+            }
             original = reinterpret_cast<decltype(original)>(method_getImplementation(method));
             method_setImplementation(method, reinterpret_cast<IMP>(custom));
         }
@@ -137,6 +202,9 @@ namespace custom_ExportedObject {
 
 + (void)load {
     custom_ExportedObject::getAllCurrentDescriptorsWithCompletion::swizzle();
+    dispatch_async(dispatch_get_main_queue(), ^{
+        custom_ExportedObject::getAllCurrentDescriptorsWithCompletion::swizzle();
+    });
 }
 
 @end


### PR DESCRIPTION
## Crash observed on device

On an iPhone running iOS 27 beta, the widget extension terminated while rebuilding `WidgetKit.DescriptorFetchResult` after the hook changed a widget descriptor. The crash report showed `EXC_BAD_ACCESS` / `SIGSEGV` in `objc_release`, with the faulting frame inside the result-rebuild path immediately after the raw `objc_msgSend(..., initWithCoder:)` call. When the extension exited, SpringBoard fell back to the regular opaque widget background.

## Root cause

The hook assumed that every private WidgetKit class, setter, decoder, and reconstruction step was available and compatible. In particular:

- Calling `initWithCoder:` through a raw `objc_msgSend` cast bypasses normal Objective-C initializer ownership conventions in ARC-enabled builds, which can lead to an invalid release.
- Private WidgetKit APIs can differ by OS version. Missing classes or setters caused the hook to continue into an unsafe reconstruction path.
- A failed decode or a descriptor that was not actually patched still proceeded to result reconstruction.

## Fix

- Replace the raw initializer dispatch with `[[descriptorFetchResultClass alloc] initWithCoder:]` so Objective-C applies the initializer ownership convention.
- Check every private class, selector, decoder, and reconstructed result before use.
- Rebuild only after a target descriptor was successfully patched.
- Return the original descriptor result on every failure path, preserving normal WidgetKit behavior instead of crashing the extension.
- Retry swizzling on the main queue in case the private export class is not ready during `+load`.

## Validation

- `xcodebuild -project MyApp.xcodeproj -scheme MyWidgetExtension -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build`
- Verified the original failure on a physical iPhone (iOS 27 beta) from the device crash report.

Fixes #5.